### PR TITLE
refactor: adjust outdir for unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: flake8
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,7 +3,7 @@ name: pytest
 on:
   push:
     branches:
-      - master
+      - '*'
   pull_request:
     branches:
       - master

--- a/tests/output/.gitignore
+++ b/tests/output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/unit/MoranProcess.py
+++ b/tests/unit/MoranProcess.py
@@ -290,12 +290,20 @@ class TestClass:
         random.seed(0)
         simulation = mp.simulate(generations=25000)
         # test the plotting:
-        moranpycess.PlotSize(mp, simulation, "./PD_size.png")
-        moranpycess.PlotAvgBirthPayoff(mp, simulation, "./PD_AvgBirthPayoff.png")
-        moranpycess.PlotAvgDeathPayoff(mp, simulation, "./PD_AvgDeathPayoff.png")
-        moranpycess.PlotBirthFitness(mp, simulation, "./PD_BirthFitness.png")
-        moranpycess.PlotDeathFitness(mp, simulation, "./PD_DeathFitness.png")
-        moranpycess.PlotEntropy(mp, simulation, "./PD_Entropy.png")
+        moranpycess.PlotSize(mp, simulation, "./tests/output/PD_size.png")
+        moranpycess.PlotAvgBirthPayoff(
+            mp, simulation, "./tests/output/PD_AvgBirthPayoff.png"
+        )
+        moranpycess.PlotAvgDeathPayoff(
+            mp, simulation, "./tests/output/PD_AvgDeathPayoff.png"
+        )
+        moranpycess.PlotBirthFitness(
+            mp, simulation, "./tests/output/PD_BirthFitness.png"
+        )
+        moranpycess.PlotDeathFitness(
+            mp, simulation, "./tests/output/PD_DeathFitness.png"
+        )
+        moranpycess.PlotEntropy(mp, simulation, "./tests/output/PD_Entropy.png")
         assert True  # mark that no error was raised before
 
     def test_MoranProcessWithTransitionMatrix(self):

--- a/tests/unit/MoranProcess2D.py
+++ b/tests/unit/MoranProcess2D.py
@@ -358,9 +358,9 @@ class TestClass:
         random.seed(0)
         simulation = mp.simulate(generations=10)
         # test the plotting:
-        moranpycess.PlotSize2D(mp, simulation, "./2D_size.png")
-        moranpycess.PlotEntropy2D(mp, simulation, "./2D_Entropy.png")
-        moranpycess.PlotPopulationSnapshot2D(mp, "./2D_snapshot.png")
+        moranpycess.PlotSize2D(mp, simulation, "./tests/output/2D_size.png")
+        moranpycess.PlotEntropy2D(mp, simulation, "./tests/output/2D_Entropy.png")
+        moranpycess.PlotPopulationSnapshot2D(mp, "./tests/output/2D_snapshot.png")
         assert True  # mark that no error was raised before
 
     def test_MoranProcess2DWithTransitionMatrix(self):

--- a/tests/unit/MoranProcess3D.py
+++ b/tests/unit/MoranProcess3D.py
@@ -555,8 +555,8 @@ class TestClass:
         random.seed(0)
         simulation = mp.simulate(generations=10)
         # test the plotting:
-        moranpycess.PlotSize3D(mp, simulation, "./3D_size.png")
-        moranpycess.PlotEntropy3D(mp, simulation, "./3D_Entropy.png")
+        moranpycess.PlotSize3D(mp, simulation, "./tests/output/3D_size.png")
+        moranpycess.PlotEntropy3D(mp, simulation, "./tests/output/3D_Entropy.png")
         assert True  # mark that no error was raised before
 
     def test_MoranProcess3DWithTransitionMatrix(self):


### PR DESCRIPTION
## Description

Example plots are now saved to a separet git-ignored dir.
That way it is clean to call `make test` locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage